### PR TITLE
Verify ORPHAcode

### DIFF
--- a/app/api/name/[term]/route.js
+++ b/app/api/name/[term]/route.js
@@ -17,7 +17,6 @@ export async function GET(req, { params }) {
             { status: 200 }
         );
     } catch (error) {
-
         return new NextResponse(
             'Something went wrong when getting the orphacodes, please try again later',
             { status: 500 }

--- a/app/api/orphacode/[term]/route.js
+++ b/app/api/orphacode/[term]/route.js
@@ -1,25 +1,24 @@
 import { NextResponse } from 'next/server';
 import { fetchOrphaInfo } from '../../fetchorphainfo';
 
-
 export async function GET(req,
   { params }) {
   const searchterm = params.term.toLowerCase();
-  const code = searchterm.replace("orpha", '')
+  const code = searchterm.replace("orpha", '').replace(":", '');
+
   try {
     let diseaseData = await fetchOrphaInfo(code)
     if (diseaseData.length === 0) {
       return new NextResponse(
-          JSON.stringify({ message: `No data found for ORPHA code ${code}` }),
-          { status: 404 }
+        JSON.stringify({ message: `No data found for ORPHA code ${code}` }),
+        { status: 404 }
       );
-  }
+    }
     return new NextResponse(
       JSON.stringify(diseaseData),
       { status: 200 }
     );
   } catch (error) {
-
     return new NextResponse(
       'Something went wrong when getting the orphacode, please try again later',
       { status: 500 }


### PR DESCRIPTION
This PR adds functionality to verify ORPHAcodes atch before merging information recieved from separate API calls.

In addition it removes inactive codes from the returned response