### PR TITLE
Fix to return any fulfilled results

### DIFF
--- a/app/api/name.js
+++ b/app/api/name.js
@@ -28,6 +28,7 @@ export async function fetchApproximateNameInfo(name) {
         return [... new Set([...diseaseData])]
 
     }).catch(error => {
+
         if (error.message.includes('404')) {
 
             return [];  // Return an empty array for 404 errors
@@ -40,10 +41,10 @@ export async function fetchApproximateNameInfo(name) {
             preferredTerm: disease["Preferred term"] || "-",
         }
     });
-    diseaseList= diseaseList.filter(disease => disease.orphacode !== undefined)
+    diseaseList = diseaseList.filter(disease => disease.orphacode !== undefined)
 
     if (diseaseList.length === 0) {
-        return diseaseData;  // Return early if no diseases found
+        return diseaseList;  // Return early if no diseases found
     } else if (diseaseList.length > 500) { // If more than 50 results are found, search term is considered too wide and an error is returned
         throw new Error('413:To many results, please refine your search');
     } else {

--- a/app/api/name.js
+++ b/app/api/name.js
@@ -11,55 +11,118 @@ export async function fetchApproximateNameInfo(name) {
     };
 
     // Fetch data using ApproximateName endpoint
-    const nameSearchData = await fetchJson(`https://api.orphacode.org/EN/ClinicalEntity/ApproximateName/${name}`, { ...options })
-        .then((values) => {
-            return values.map(disease => {
-                return {
-                    orphacode: disease.ORPHAcode,
-                    preferredTerm: disease["Preferred term"] || "-",
-                };
-            });
+
+    const diseaseList= await Promise.allSettled([
+        fetchJson(`https://api.orphacode.org/EN/ClinicalEntity/ApproximateName/${name}`, { ...options }),
+        fetchJson(`https://api.orphacode.org/EN/ClinicalEntity/ApproximateName/${name}/Synonym`, { ...options }),
+    ]).then((values) => {
+        let diseaseData = [];
+        values.forEach((value) => {
+            if (value.status === 'fulfilled') {
+                console.log('value.value.length')
+                console.log(value.value.length)
+                const valueSet=[... new Set([...value.value])]
+                diseaseData = [...diseaseData, ...valueSet];
+            }
+        });
+    
+            return [... new Set([...diseaseData])]
+
         }).catch(error => {
+            console.log('This was the error error')
+            console.log(error)
             if (error.message.includes('404')) {
+
                 return [];  // Return an empty array for 404 errors
             }
             throw error;  // Re-throw other errors
         });
+        console.log(diseaseList)
 
-    // Fetch synonyms using ApproximateName endpoint
-    const synonymSearchData = await fetchJson(`https://api.orphacode.org/EN/ClinicalEntity/ApproximateName/${name}/Synonym`, { ...options })
-        .then((values) => {
-            return values.map(disease => {
-                return {
-                    orphacode: disease.ORPHAcode,
-                    preferredTerm: disease["Preferred term"] || "-",
-                };
-            })
-        }).catch(error => {
-            if (error.message.includes('404')) {
-                return [];  // Return an empty array for 404 errors
-            }
-            throw error;  // Re-throw other errors
-        });
-
-    // Merge synonym and name results
-    const diseaseData = [... new Set([...nameSearchData, ...synonymSearchData])];
-
-    if (diseaseData.length === 0) {
-        return diseaseData;  // Return early if no diseases found
+        if (diseaseList.length === 0) {
+            return diseaseData;  // Return early if no diseases found
+        }else if(diseaseList.length>50){
+            throw new Error('To many results, please refine your search');
+        }else{
+            return Promise.allSettled([
+                removeInactive(diseaseList),
+                fetchSynonyms(diseaseList),
+                fetchICD10Codes(diseaseList),
+                fetchClassificationLevel(diseaseList)
+            ]).then((values) => {
+                let diseaseData = [];
+                console.log(values)
+                values.forEach((value) => {
+                    if (value.status === 'fulfilled') {
+                        diseaseData = [...diseaseData, ...value.value];
+                    }
+                });
+                return diseaseData;
+            }).catch(error => {
+                console.log('This was the error error')
+                console.log(error)
+                if (error.message.includes('404')) {
+                    return [];  // Return an empty array for 404 errors
+                }
+                throw error;  // Re-throw other errors
+            }); 
+        }
     }
 
-    //Remove inactive diseases
-    const activeDiseaseData = await removeInactive(diseaseData);
+ 
+ 
+        /*     const nameSearchData = await fetchJson(`https://api.orphacode.org/EN/ClinicalEntity/ApproximateName/${name}`, { ...options })
+                .then((values) => {
+            
+                    return values.map(disease => {
+                        return {
+                            orphacode: disease.ORPHAcode,
+                            preferredTerm: disease["Preferred term"] || "-",
+                        };
+                    });
+                }).catch(error => {
+                    console.log('This was the error error')
+                    console.log(error)
+                    if (error.message.includes('404')) {
+                        return [];  // Return an empty array for 404 errors
+                    }
+                    throw error;  // Re-throw other errors
+                });
+        
+            // Fetch synonyms using ApproximateName endpoint
+            const synonymSearchData = await fetchJson(`https://api.orphacode.org/EN/ClinicalEntity/ApproximateName/${name}/Synonym`, { ...options })
+                .then((values) => {
+                    return values.map(disease => {
+                        return {
+                            orphacode: disease.ORPHAcode,
+                            preferredTerm: disease["Preferred term"] || "-",
+                        };
+                    })
+                }).catch(error => {
+                    if (error.message.includes('404')) {
+                        return [];  // Return an empty array for 404 errors
+                    }
+                    throw error;  // Re-throw other errors
+                }); */
 
-    // Fetch synonyms for each disease
-    let diseaseWithSynonyms = await fetchSynonyms(activeDiseaseData);
+        // Merge synonym and name results
+        // const diseaseData = [... new Set([...nameSearchData, ...synonymSearchData])];
+/* 
+        if (diseaseData.length === 0) {
+            return diseaseData;  // Return early if no diseases found
+        }
 
-    // Fetch ICD-10 codes for each disease
-    const diseaseWithICD10 = await fetchICD10Codes(diseaseWithSynonyms);
+        //Remove inactive diseases
+        const activeDiseaseData = await removeInactive(diseaseData);
 
-    // Fetch classification level for each disease
-    const completeDiseaseData = await fetchClassificationLevel(diseaseWithICD10);
+        // Fetch synonyms for each disease
+        let diseaseWithSynonyms = await fetchSynonyms(activeDiseaseData);
 
-    return completeDiseaseData;
-}
+        // Fetch ICD-10 codes for each disease
+        const diseaseWithICD10 = await fetchICD10Codes(diseaseWithSynonyms);
+
+        // Fetch classification level for each disease
+        const completeDiseaseData = await fetchClassificationLevel(diseaseWithICD10);
+
+        return completeDiseaseData; 
+    }*/

--- a/app/api/name.js
+++ b/app/api/name.js
@@ -42,7 +42,7 @@ export async function fetchApproximateNameInfo(name) {
         if (diseaseList.length === 0) {
             return diseaseData;  // Return early if no diseases found
         }else if(diseaseList.length>50){
-            throw new Error('To many results, please refine your search');
+            throw new Error('413:To many results, please refine your search');
         }else{
             return Promise.allSettled([
                 removeInactive(diseaseList),
@@ -68,61 +68,3 @@ export async function fetchApproximateNameInfo(name) {
             }); 
         }
     }
-
- 
- 
-        /*     const nameSearchData = await fetchJson(`https://api.orphacode.org/EN/ClinicalEntity/ApproximateName/${name}`, { ...options })
-                .then((values) => {
-            
-                    return values.map(disease => {
-                        return {
-                            orphacode: disease.ORPHAcode,
-                            preferredTerm: disease["Preferred term"] || "-",
-                        };
-                    });
-                }).catch(error => {
-                    console.log('This was the error error')
-                    console.log(error)
-                    if (error.message.includes('404')) {
-                        return [];  // Return an empty array for 404 errors
-                    }
-                    throw error;  // Re-throw other errors
-                });
-        
-            // Fetch synonyms using ApproximateName endpoint
-            const synonymSearchData = await fetchJson(`https://api.orphacode.org/EN/ClinicalEntity/ApproximateName/${name}/Synonym`, { ...options })
-                .then((values) => {
-                    return values.map(disease => {
-                        return {
-                            orphacode: disease.ORPHAcode,
-                            preferredTerm: disease["Preferred term"] || "-",
-                        };
-                    })
-                }).catch(error => {
-                    if (error.message.includes('404')) {
-                        return [];  // Return an empty array for 404 errors
-                    }
-                    throw error;  // Re-throw other errors
-                }); */
-
-        // Merge synonym and name results
-        // const diseaseData = [... new Set([...nameSearchData, ...synonymSearchData])];
-/* 
-        if (diseaseData.length === 0) {
-            return diseaseData;  // Return early if no diseases found
-        }
-
-        //Remove inactive diseases
-        const activeDiseaseData = await removeInactive(diseaseData);
-
-        // Fetch synonyms for each disease
-        let diseaseWithSynonyms = await fetchSynonyms(activeDiseaseData);
-
-        // Fetch ICD-10 codes for each disease
-        const diseaseWithICD10 = await fetchICD10Codes(diseaseWithSynonyms);
-
-        // Fetch classification level for each disease
-        const completeDiseaseData = await fetchClassificationLevel(diseaseWithICD10);
-
-        return completeDiseaseData; 
-    }*/

--- a/app/api/name/[term]/route.js
+++ b/app/api/name/[term]/route.js
@@ -6,7 +6,7 @@ export async function GET(req, { params }) {
 
     try {
         const diseaseData = await fetchApproximateNameInfo(name);
-        console.log(diseaseData)
+
         if (diseaseData.length === 0) {
             return new NextResponse(
                 JSON.stringify({ message: `No data found for name ${name}` }),

--- a/app/api/name/[term]/route.js
+++ b/app/api/name/[term]/route.js
@@ -18,10 +18,14 @@ export async function GET(req, { params }) {
             { status: 200 }
         );
     } catch (error) {
-        console.log('This was the error in name route')
-        console.log(error)
+        if ( error.message.includes('413')) {
+            return new NextResponse(
+                JSON.stringify({ message: `To many results for "${name}", please refine your search` }),
+                { status: 413 }
+            );
+        }
         return new NextResponse(
-            'Something went wrong when getting the orphacodes, please try again later',
+            JSON.stringify({message:'Something went wrong when getting the orphacodes, please try again later'}),
             { status: 500 }
         );
     }

--- a/app/api/name/[term]/route.js
+++ b/app/api/name/[term]/route.js
@@ -6,6 +6,7 @@ export async function GET(req, { params }) {
 
     try {
         const diseaseData = await fetchApproximateNameInfo(name);
+        console.log(diseaseData)
         if (diseaseData.length === 0) {
             return new NextResponse(
                 JSON.stringify({ message: `No data found for name ${name}` }),
@@ -17,6 +18,8 @@ export async function GET(req, { params }) {
             { status: 200 }
         );
     } catch (error) {
+        console.log('This was the error in name route')
+        console.log(error)
         return new NextResponse(
             'Something went wrong when getting the orphacodes, please try again later',
             { status: 500 }

--- a/app/api/orphacode.js
+++ b/app/api/orphacode.js
@@ -37,8 +37,6 @@ export async function fetchOrphaInfo(code) {
             return [disease];
         }
     }).catch(error => {
-        console.log('This was the error error')
-        console.log(error)
         if (error.message.includes('404')) {
 
             return [];  // Return an empty array for 404 errors

--- a/app/api/utils.js
+++ b/app/api/utils.js
@@ -20,6 +20,7 @@ export async function fetchICD10Codes(diseaseData) {
         },
     };
 
+    //Create an array of fetch calls for each disease 
     const apiCalls = diseaseData.map(disease => {
         return fetchJson(`https://api.orphacode.org/EN/ClinicalEntity/orphacode/${disease.orphacode}/ICD10`, { ...options })
             .catch(error => {

--- a/components/searchbox.jsx
+++ b/components/searchbox.jsx
@@ -63,6 +63,8 @@ export function SearchBox() {
                 }
                 setSearchResultList(data)
             }).catch(error => {
+                console.log('This was the error error in searchbox')
+                console.log(error)
                 setSearchResultList([])
                 toast.error('Something went wrong, please try again later')
             })

--- a/components/searchbox.jsx
+++ b/components/searchbox.jsx
@@ -30,7 +30,7 @@ export function SearchBox() {
                 }
                 break
             case "icd10":
-                if (!searchTerm.match( /[A-Za-z][0-9]+\.[0-9]+/i)) {
+                if (!searchTerm.match(/[A-Za-z][0-9]+\.[0-9]+/i)) {
                     toast.error('ICD-10 code must be in the format A12.3')
                     return false
                 }
@@ -63,8 +63,6 @@ export function SearchBox() {
                 }
                 setSearchResultList(data)
             }).catch(error => {
-                console.log('This was the error error in searchbox')
-                console.log(error)
                 setSearchResultList([])
                 toast.error('Something went wrong, please try again later')
             })


### PR DESCRIPTION
This PR contains the updates replacing promise.all with promise.allSettled where relevant to return any data from Orphanet API as well as adjustments to handle name searches providing to many matches.

Functionality updated to handle new format of response.
Simpoultaneous API calls used when possible to limit the number of consecutive calls.